### PR TITLE
Fix broken 99bionic-updates link

### DIFF
--- a/apps/Firefox/install
+++ b/apps/Firefox/install
@@ -9,7 +9,7 @@ echo "deb http://ports.ubuntu.com/ubuntu-ports bionic-updates main" | sudo tee /
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
 
 # Add preferences so the ubuntu repositories don't become your "default" repositories
-wget -O 99bionic-updates https://bit.ly/3o4Buhf
+wget -O 99bionic-updates https://git.io/JsdJ6
 sudo mv 99bionic-updates /etc/apt/preferences.d/99bionic-updates
 
 # Finally, get the packages and update.


### PR DESCRIPTION
I realized that the link, which downloaded the `99bionic-updates` file, was invalid. the install script will not work until this is merged