### PR TITLE
Fix lunar apt issue

### DIFF
--- a/apps/Lunar_Client/install
+++ b/apps/Lunar_Client/install
@@ -8,7 +8,7 @@ if ! command -v modprobe >/dev/null;then
   
   if [ -f /usr/bin/apt ];then
     sudo apt update
-    sudo apt install -y modprobe || echo "Failed to install modprobe."
+    sudo apt install -y kmod || echo "Failed to install modprobe."
   else
     error "Failed to find any package manager to install modprobe."
   fi
@@ -96,29 +96,22 @@ rm -rf libopenal.so
 cd
 cp lwjgl3arm32/libopenal.so $HOME/lwjgl2arm32
 
-#Add icon
-cd
-mkdir lunarassets
-cd lunarassets
-wget https://github.com/gl91306/lunar/raw/master/lunarclient.png
-cd
-
 #Then make menu button & desktop icon
 echo "Creating a desktop entry for Lunar-Client..."
 echo "[Desktop Entry]
 Name=Lunar Client
-Comment=Lunar Client for Rpi made by PiKATchu on Discord.
+Comment=Minecraft Lunar Client for RPI made by PiKATchu on Discord.
 Exec=$HOME/lunarclient-2.7.3b-armv7l.AppImage
-Icon=$HOME/lunarassets/lunarclient.png
+Icon=$HOME/pi-ware/apps/Lunar_Client/icon.png
 Categories=Game;
 Type=Application
 Terminal=false" > "$HOME/.local/share/applications/Lunar-Client.desktop"
 
 echo "[Desktop Entry]
 Name=Lunar Client
-Comment=Lunar Client for Rpi made by PiKATchu on Discord.
+Comment=Minecraft Lunar Client for RPI made by PiKATchu on Discord.
 Exec=$HOME/lunarclient-2.7.3b-armv7l.AppImage
-Icon=$HOME/lunarassets/lunarclient.png
+Icon=$HOME/pi-ware/apps/Lunar_Client/icon.png
 Categories=Game;
 Type=Application
 Terminal=false" > "$HOME/Desktop/Lunar Client"


### PR DESCRIPTION
mdoprobe's name in apt is kmod according to https://command-not-found.com/modprobe so this fixes it up. I also changed the desktop shortcut icons to use the icon from pi-ware instead of downloading it from lunar's website.